### PR TITLE
Unified version interpolate

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+RUBY_VERSION=2.5.0

--- a/Dockerfile.centos5
+++ b/Dockerfile.centos5
@@ -1,4 +1,5 @@
 FROM centos:5
+ARG RUBY_VERSION=
 
 RUN yum -y update
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
@@ -7,7 +8,6 @@ RUN yum -y install wget tar git zlib-devel openssl-devel readline-devel
 
 RUN mkdir -p /usr/local/rbenv/versions
 RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/ruby-build
-ENV RUBY_VERSION 2.4.3
 RUN CONFIGURE_OPTS="--disable-install-doc --enable-bundled-libyaml --enable-bundled-libffi --with-out-ext='win32*,tk*'" /tmp/ruby-build/bin/ruby-build $RUBY_VERSION /usr/local/rbenv/versions/$RUBY_VERSION
 RUN rm -rf /tmp/ruby-build
 

--- a/Dockerfile.centos5
+++ b/Dockerfile.centos5
@@ -1,5 +1,4 @@
 FROM centos:5
-MAINTAINER hsbt@ruby-lang.org
 
 RUN yum -y update
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -1,4 +1,5 @@
 FROM centos:6
+ARG RUBY_VERSION=
 
 RUN yum -y update
 RUN yum -y groupinstall "Development Tools"
@@ -6,7 +7,6 @@ RUN yum -y install wget tar zlib-devel openssl-devel readline-devel
 
 RUN mkdir -p /usr/local/rbenv/versions
 RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/ruby-build
-ENV RUBY_VERSION 2.4.3
 RUN CONFIGURE_OPTS="--disable-install-doc --enable-bundled-libyaml --enable-bundled-libffi --with-out-ext='win32*,tk*'" /tmp/ruby-build/bin/ruby-build $RUBY_VERSION /usr/local/rbenv/versions/$RUBY_VERSION
 RUN rm -rf /tmp/ruby-build
 

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -1,5 +1,4 @@
 FROM centos:6
-MAINTAINER hsbt@ruby-lang.org
 
 RUN yum -y update
 RUN yum -y groupinstall "Development Tools"

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,5 +1,4 @@
 FROM centos:7
-MAINTAINER hsbt@ruby-lang.org
 
 RUN yum -y update
 RUN yum -y groupinstall "Development Tools"

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,4 +1,5 @@
 FROM centos:7
+ARG RUBY_VERSION=
 
 RUN yum -y update
 RUN yum -y groupinstall "Development Tools"
@@ -7,7 +8,6 @@ RUN yum -y install wget zlib-devel openssl-devel readline-devel openssl
 RUN yum update openssl
 RUN mkdir -p /usr/local/rbenv/versions
 RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/ruby-build
-ENV RUBY_VERSION 2.4.3
 RUN CONFIGURE_OPTS="--disable-install-doc --enable-bundled-libyaml --enable-bundled-libffi --with-out-ext='win32*,tk*'" /tmp/ruby-build/bin/ruby-build $RUBY_VERSION /usr/local/rbenv/versions/$RUBY_VERSION
 RUN rm -rf /tmp/ruby-build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,31 @@
-centos5:
-  dockerfile: Dockerfile.centos5
-  build: .
-  command: cp -a /out/rbenv-ruby-2.4.3.tar.gz /tmp
-  volumes:
-    - .:/tmp:rw
+version: "2"
+services:
+  centos5:
+    build:
+      dockerfile: Dockerfile.centos5
+      context: .
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+    command: "cp -a /out/rbenv-ruby-${RUBY_VERSION}.tar.gz /tmp"
+    volumes:
+      - .:/tmp:rw
 
-centos6:
-  dockerfile: Dockerfile.centos6
-  build: .
-  command: cp -a /out/rbenv-ruby-2.4.3.tar.gz /tmp
-  volumes:
-    - .:/tmp:rw
+  centos6:
+    build:
+      dockerfile: Dockerfile.centos6
+      context: .
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+    command: "cp -a /out/rbenv-ruby-${RUBY_VERSION}.tar.gz /tmp"
+    volumes:
+      - .:/tmp:rw
 
-centos7:
-  dockerfile: Dockerfile.centos7
-  build: .
-  command: cp -a /out/rbenv-ruby-2.4.3.tar.gz /tmp
-  volumes:
-    - .:/tmp:rw
+  centos7:
+    build:
+      dockerfile: Dockerfile.centos7
+      context: .
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+    command: "cp -a /out/rbenv-ruby-${RUBY_VERSION}.tar.gz /tmp"
+    volumes:
+      - .:/tmp:rw


### PR DESCRIPTION
Before:

You need to update RUBY_VERSION on docker-compose.yml and Dockerfile.*
    
After:

You don't need to update them. You can only invoke the following command with RUBY_VERSION environmental variable.

```
$  env RUBY_VERSION=2.3.4 docker-compose run centos7
```

Our default version stored .env file.
